### PR TITLE
EM-3401 Set hearing recording Metadata timestamp format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencyCheck {
 dependencyManagement {
   dependencies {
 
-    dependencySet(group: 'com.google.guava', version: '30.1-jre') {
+    dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
       // Guava CVE-2018-10237 - Unbounded memory allocation
       entry 'guava'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.18'
   implementation "ch.qos.logback:logback-classic:1.2.3"
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
 
   //azure components
   implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.10.1'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/av/AntivirusClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/av/AntivirusClientIntegrationTest.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import uk.gov.hmcts.reform.em.hrs.ingestor.av.mock.ClamAvInitializer;
 import uk.gov.hmcts.reform.em.hrs.ingestor.config.ClamAvConfig;
-import uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants;
+import uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -14,8 +14,8 @@ import java.net.URISyntaxException;
 import javax.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.CLEAN_FILE;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.INFECTED_FILE;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.CLEAN_FILE;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.INFECTED_FILE;
 
 @SpringBootTest(classes = {ClamAvConfig.class, AntivirusClientImpl.class})
 @ContextConfiguration(initializers = {ClamAvInitializer.class})
@@ -45,7 +45,7 @@ class AntivirusClientIntegrationTest {
     }
 
     private InputStream getFileAsInputStream(final String filename) throws IOException, URISyntaxException {
-        final byte[] data = TestConstants.getFileContent(filename);
+        final byte[] data = TestUtil.getFileContent(filename);
         return new ByteArrayInputStream(data);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/helper/TestConstants.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/helper/TestConstants.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.em.hrs.ingestor.helper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -19,5 +22,11 @@ public interface TestConstants {
         final File file = Paths.get(Objects.requireNonNull(resource).toURI()).toFile();
 
         return Files.readAllBytes(file.toPath());
+    }
+
+    static String convertObjectToJsonString(Object object) throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        return objectMapper.writeValueAsString(object);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/helper/TestUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/helper/TestUtil.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.em.hrs.ingestor.helper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,14 +10,14 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-public interface TestConstants {
+public interface TestUtil {
     String INFECTED_FILE = "eicar-standard-av-test-file";
     String CLEAN_FILE = "cf-0266-hu-02785-2020_2020-07-16-10.07.31.680-UTC_0.txt";
     String INFECTED_FOLDER = "infected-folder";
     String CLEAN_FOLDER = "audiostream123";
 
     static byte[] getFileContent(final String filename) throws URISyntaxException, IOException {
-        final URL resource = TestConstants.class.getClassLoader().getResource(filename);
+        final URL resource = TestUtil.class.getClassLoader().getResource(filename);
         final File file = Paths.get(Objects.requireNonNull(resource).toURI()).toFile();
 
         return Files.readAllBytes(file.toPath());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/http/HrsApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/http/HrsApiClientIntegrationTest.java
@@ -26,7 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.convertObjectToJsonString;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.convertObjectToJsonString;
 
 @SpringBootTest(classes = {TestOkHttpClientConfig.class, AppConfig.class, HrsApiClientImpl.class})
 @ContextConfiguration(initializers = {WireMockInitializer.class})

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/http/HrsApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/http/HrsApiClientIntegrationTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import javax.inject.Inject;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -25,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.convertObjectToJsonString;
 
 @SpringBootTest(classes = {TestOkHttpClientConfig.class, AppConfig.class, HrsApiClientImpl.class})
 @ContextConfiguration(initializers = {WireMockInitializer.class})
@@ -38,14 +40,14 @@ class HrsApiClientIntegrationTest {
         "recording-cvp-uri",
         1L,
         "I2foA30B==",
-        null,
+        "recording-ref",
         0,
         "mp4",
         LocalDateTime.now(),
         "xyz",
         222,
         "AB",
-        null
+        "C3"
     );
 
     @Inject
@@ -149,6 +151,7 @@ class HrsApiClientIntegrationTest {
 
     @Test
     void testShouldPostDataSuccessfully() throws Exception {
+        final String expectedPayload = convertObjectToJsonString(METADATA);
         wireMockServer.stubFor(
             WireMock.post(urlPathEqualTo(POST_PATH))
                 .willReturn(aResponse()
@@ -157,7 +160,8 @@ class HrsApiClientIntegrationTest {
 
         underTest.postFile(METADATA);
 
-        wireMockServer.verify(exactly(1), postRequestedFor(urlEqualTo(POST_PATH)));
+        wireMockServer.verify(exactly(1), postRequestedFor(urlEqualTo(POST_PATH))
+            .withRequestBody(equalTo(expectedPayload)));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/service/IngestorServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/em/hrs/ingestor/service/IngestorServiceIntegrationTest.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.em.hrs.ingestor.config.ClamAvConfig;
 import uk.gov.hmcts.reform.em.hrs.ingestor.config.TestAzureStorageConfiguration;
 import uk.gov.hmcts.reform.em.hrs.ingestor.config.TestOkHttpClientConfig;
 import uk.gov.hmcts.reform.em.hrs.ingestor.helper.AzureOperations;
-import uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants;
+import uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil;
 import uk.gov.hmcts.reform.em.hrs.ingestor.http.HrsApiClientImpl;
 import uk.gov.hmcts.reform.em.hrs.ingestor.http.mock.WireMockInitializer;
 import uk.gov.hmcts.reform.em.hrs.ingestor.storage.CvpBlobstoreClientImpl;
@@ -28,10 +28,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.CLEAN_FILE;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.CLEAN_FOLDER;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.INFECTED_FILE;
-import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestConstants.INFECTED_FOLDER;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.CLEAN_FILE;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.CLEAN_FOLDER;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.INFECTED_FILE;
+import static uk.gov.hmcts.reform.em.hrs.ingestor.helper.TestUtil.INFECTED_FOLDER;
 
 @SpringBootTest(classes = {
     TestOkHttpClientConfig.class,
@@ -104,7 +104,7 @@ class IngestorServiceIntegrationTest {
     }
 
     private void setupCvpBlobstore(final String folder, final String file) throws Exception {
-        final byte[] data = TestConstants.getFileContent(file);
+        final byte[] data = TestUtil.getFileContent(file);
         azureOperations.uploadToContainer(folder + "/" + file, data);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/ingestor/config/AppConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/ingestor/config/AppConfig.java
@@ -18,15 +18,18 @@ public class AppConfig {
 
     @Bean
     public ObjectMapper provideObjectMapper() {
-        return new ObjectMapper()
+        final ObjectMapper objectMapper = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.findAndRegisterModules();
+
+        return objectMapper;
     }
 
     @Bean
-    public Retrofit provideRetrofit(final OkHttpClient okHttpClient) {
+    public Retrofit provideRetrofit(final ObjectMapper objectMapper, final OkHttpClient okHttpClient) {
         return new Retrofit.Builder()
             .baseUrl(hrsApiBaseUrl)
-            .addConverterFactory(JacksonConverterFactory.create())
+            .addConverterFactory(JacksonConverterFactory.create(objectMapper))
             .client(okHttpClient)
             .build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/em/hrs/ingestor/model/Metadata.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/hrs/ingestor/model/Metadata.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.em.hrs.ingestor.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ public class Metadata {
     private final String recordingRef;
     private final int segment;
     private final String filenameExtension;
+    @JsonFormat(pattern = "yyyy-MM-dd-HH.mm.ss.SSS")
     private final LocalDateTime recordingDateTime;
     private final String caseRef;
     private final String recordingSource = "CVP";


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3401


### Change description ###
Set the hearing recording timestamp format on the request payload going out to em-hrs-api
pattern = "yyyy-MM-dd-HH.mm.ss.SSS"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
