### PR TITLE
Nojira set logging to info for parser and use vault for hrs container name

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -30,11 +30,11 @@ def secrets = [
   'em-hrs-api-${env}': [
     secret('cvp-storage-connection-string', 'AAT_CVP_STORAGE_CONNECTION_STRING'),
     secret('storage-account-primary-connection-string', 'AAT_HRS_STORAGEACCOUNT_CONNECTION_STRING'),
-    secret('cvp-storage-container-name', 'AAT_CVP_STORAGE_CONTAINER_NAME')
+    secret('cvp-storage-container-name', 'AAT_CVP_STORAGE_CONTAINER_NAME'),
+    secret('hrs-storage-container-name', 'AAT_HRS_STORAGE_CONTAINER_NAME')
   ]
 ]
 
-env.AAT_HRS_STORAGE_CONTAINER_NAME='recordings'
 
 GradleBuilder builder = new GradleBuilder(this, product)
 

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -3,5 +3,5 @@
   <include resource="org/springframework/boot/logging/logback/base.xml"/>
   <logger name="org.springframework.context" level="WARN"/>
   <logger name="org.springframework.web.context" level="WARN"/>
-  <logger name="uk.gov.hmcts.reform.em.hrs.ingestor.parse" level="DEBUG"/>
+  <logger name="uk.gov.hmcts.reform.em.hrs.ingestor.parse" level="INFO"/>
 </configuration>

--- a/src/test/java/uk/gov/hmcts/reform/em/hrs/ingestor/parse/FilenameParserWithFullDataExtractTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/hrs/ingestor/parse/FilenameParserWithFullDataExtractTest.java
@@ -89,8 +89,6 @@ class FilenameParserWithFullDataExtractTest {
             log.debug("The Only Case ID Scenario");
             assertNull(parsedFilenameDto.getJurisdiction());
             assertNull(parsedFilenameDto.getLocationCode());
-            assertNull(parsedFilenameDto.getRecordingDateTime());
-            assertNull(parsedFilenameDto.getSegment());
             assertTrue(caseReference.equalsIgnoreCase(parsedFilenameDto.getCaseID()));
         }
         log.debug("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
change logging for parser from debug to info
use vault for hrs container name instead of hardcoded value


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
