### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,7 +297,7 @@ def versions = [
   junit              : '5.7.1',
   junitPlatform      : '1.8.1',
   reformLogging      : '5.1.7',
-  log4JVersion       : "2.16.0",
+  log4JVersion       : "2.17.0",
   springBoot         : springBoot.class.package.implementationVersion,
   springfoxSwagger   : '2.9.2',
   pact_version       : '3.6.15',


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105